### PR TITLE
Create unit test for the TextToSpeechPlayer component

### DIFF
--- a/frontend/src/__tests__/components/Items/Misc/AudioPlayerControls.test.tsx
+++ b/frontend/src/__tests__/components/Items/Misc/AudioPlayerControls.test.tsx
@@ -1,0 +1,68 @@
+import { describe, it, beforeEach, vi } from "vitest";
+import { render, fireEvent, screen } from "@testing-library/react";
+import AudioPlayerControls from "./../../../../components/Items/Misc/AudioPlayerControls";
+
+describe("AudioPlayerControls", () => {
+	let mockHandlePlayPause: vi.Mock;
+	let mockHandleRepeat: vi.Mock;
+	let mockHandleRestart: vi.Mock;
+
+	beforeEach(() => {
+		mockHandlePlayPause = vi.fn();
+		mockHandleRepeat = vi.fn();
+		mockHandleRestart = vi.fn();
+	});
+
+	afterEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("renders the restart button", () => {
+		render(<AudioPlayerControls isPlaying={false} isRepeating={false} handlePlayPause={mockHandlePlayPause} handleRepeat={mockHandleRepeat} handleRestart={mockHandleRestart} />);
+		expect(screen.getByTestId("testid-restart-button")).toBeInTheDocument();
+	});
+
+	it("renders the play/pause button", () => {
+		render(<AudioPlayerControls isPlaying={false} isRepeating={false} handlePlayPause={mockHandlePlayPause} handleRepeat={mockHandleRepeat} handleRestart={mockHandleRestart} />);
+		expect(screen.getByTestId("testid-playpause-button")).toBeInTheDocument();
+	});
+
+	it("renders the repeat button", () => {
+		render(<AudioPlayerControls isPlaying={false} isRepeating={false} handlePlayPause={mockHandlePlayPause} handleRepeat={mockHandleRepeat} handleRestart={mockHandleRestart} />);
+		expect(screen.getByTestId("testid-repeat-button")).toBeInTheDocument();
+	});
+
+	it("renders the play icon when isPlaying is false", () => {
+		render(<AudioPlayerControls isPlaying={false} isRepeating={false} handlePlayPause={mockHandlePlayPause} handleRepeat={mockHandleRepeat} handleRestart={mockHandleRestart} />);
+
+		expect(screen.queryByTestId("testid-play-icon")).toBeInTheDocument();
+		expect(screen.queryByTestId("testid-pause-icon")).not.toBeInTheDocument();
+	});
+
+	it("renders the pause icon when isPlaying is true", () => {
+		render(<AudioPlayerControls isPlaying={true} isRepeating={false} handlePlayPause={mockHandlePlayPause} handleRepeat={mockHandleRepeat} handleRestart={mockHandleRestart} />);
+		expect(screen.queryByTestId("testid-play-icon")).not.toBeInTheDocument();
+		expect(screen.queryByTestId("testid-pause-icon")).toBeInTheDocument();
+	});
+
+	it("calls the handlePlayPause function when the play/pause button is clicked", () => {
+		render(<AudioPlayerControls isPlaying={false} isRepeating={false} handlePlayPause={mockHandlePlayPause} handleRepeat={mockHandleRepeat} handleRestart={mockHandleRestart} />);
+		const playButton = screen.getByTestId("testid-playpause-button");
+		fireEvent.click(playButton);
+		expect(mockHandlePlayPause).toHaveBeenCalledTimes(1);
+	});
+
+	it("calls the handleRepeat function when the repeat button is clicked", () => {
+		render(<AudioPlayerControls isPlaying={false} isRepeating={false} handlePlayPause={mockHandlePlayPause} handleRepeat={mockHandleRepeat} handleRestart={mockHandleRestart} />);
+		const repeatButton = screen.getByTestId("testid-repeat-button");
+		fireEvent.click(repeatButton);
+		expect(mockHandleRepeat).toHaveBeenCalledTimes(1);
+	});
+
+	it("calls the handleRestart function when the rewind button is clicked", () => {
+		render(<AudioPlayerControls isPlaying={false} isRepeating={false} handlePlayPause={mockHandlePlayPause} handleRepeat={mockHandleRepeat} handleRestart={mockHandleRestart} />);
+		const rewindButton = screen.getByTestId("testid-restart-button");
+		fireEvent.click(rewindButton);
+		expect(mockHandleRestart).toHaveBeenCalledTimes(1);
+	});
+});

--- a/frontend/src/__tests__/components/Items/Misc/AudioPlayerPlaybackSpeed.test.tsx
+++ b/frontend/src/__tests__/components/Items/Misc/AudioPlayerPlaybackSpeed.test.tsx
@@ -1,0 +1,38 @@
+import { render, fireEvent } from "@testing-library/react";
+import { describe, it, vi } from "vitest";
+import AudioPlayerPlaybackSpeed from "./../../../../components/Items/Misc/AudioPlayerPlaybackSpeed";
+
+describe("AudioPlayerPlaybackSpeed", () => {
+	let setPlaybackRate: vi.Mock;
+	beforeEach(() => {
+		setPlaybackRate = vi.fn();
+	});
+
+	it("renders with correct initial value", () => {
+		const { getByDisplayValue } = render(<AudioPlayerPlaybackSpeed playbackRate={1} setPlaybackRate={setPlaybackRate} />);
+		expect(getByDisplayValue("1x")).toBeInTheDocument();
+	});
+
+	it("renders all options correctly", () => {
+		const { getByText } = render(<AudioPlayerPlaybackSpeed playbackRate={1} setPlaybackRate={setPlaybackRate} />);
+		expect(getByText("0.5x")).toBeInTheDocument();
+		expect(getByText("1x")).toBeInTheDocument();
+		expect(getByText("1.5x")).toBeInTheDocument();
+		expect(getByText("2x")).toBeInTheDocument();
+	});
+
+	it("changes value when different option is selected", () => {
+		const { getByDisplayValue } = render(<AudioPlayerPlaybackSpeed playbackRate={1} setPlaybackRate={setPlaybackRate} />);
+		fireEvent.change(getByDisplayValue("1x"), { target: { value: "0.5" } });
+		expect(setPlaybackRate).toHaveBeenCalledWith(0.5);
+	});
+
+	it("handles multiple select changes correctly", () => {
+		const { getByDisplayValue } = render(<AudioPlayerPlaybackSpeed playbackRate={1} setPlaybackRate={setPlaybackRate} />);
+		fireEvent.change(getByDisplayValue("1x"), { target: { value: "0.5" } });
+		expect(setPlaybackRate).toHaveBeenLastCalledWith(0.5);
+		fireEvent.change(getByDisplayValue("1x"), { target: { value: "1.5" } });
+		expect(setPlaybackRate).toHaveBeenLastCalledWith(1.5);
+		expect(setPlaybackRate).toHaveBeenCalledTimes(2);
+	});
+});

--- a/frontend/src/__tests__/components/Items/Misc/AudioPlayerProgressBar.test.tsx
+++ b/frontend/src/__tests__/components/Items/Misc/AudioPlayerProgressBar.test.tsx
@@ -1,0 +1,32 @@
+import { render, fireEvent, RenderResult } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import AudioPlayerProgressBar from './../../../../components/Items/Misc/AudioPlayerProgressBar';
+import { AudioPlayerProgressBarProps } from '../../../../types/props';
+
+describe('AudioPlayerProgressBar', () => {
+	let props: AudioPlayerProgressBarProps;
+	let container: RenderResult;
+
+	beforeEach(() => {
+		props = {
+			currentTime: 30,
+			duration: 120,
+			handleAudioPlayerProgressBarClick: vi.fn(),
+		};
+
+		container = render(<AudioPlayerProgressBar {...props} />);
+	});
+
+	it('renders correctly with initial props', () => {
+		const input = container.getByRole('slider')  as HTMLInputElement;
+		expect(input).toBeInTheDocument();
+		expect(input.value).toBe(String(props.currentTime));
+		expect(input.max).toBe(String(props.duration));
+	});
+
+	it('calls handleAudioPlayerProgressBarClick when slider is moved', () => {
+		const input = container.getByRole('slider');
+		fireEvent.change(input, { target: { value: 60 } });
+		expect(props.handleAudioPlayerProgressBarClick).toHaveBeenCalledTimes(1);
+	});
+});

--- a/frontend/src/__tests__/components/Items/Misc/FullAudioPlayer.test.tsx
+++ b/frontend/src/__tests__/components/Items/Misc/FullAudioPlayer.test.tsx
@@ -1,0 +1,114 @@
+import { describe, it, beforeEach, vi } from "vitest";
+import { render } from "@testing-library/react";
+import FullAudioPlayer from "./../../../../components/Items/Misc/FullAudioPlayer";
+import AudioPlayerControls from "./../../../../components/Items/Misc/AudioPlayerControls";
+import AudioPlayerProgressBar from "./../../../../components/Items/Misc/AudioPlayerProgressBar";
+import AudioPlayerPlaybackSpeed from "./../../../../components/Items/Misc/AudioPlayerPlaybackSpeed";
+
+vi.mock("./../../../../components/Items/Misc/AudioPlayerControls");
+vi.mock("./../../../../components/Items/Misc/AudioPlayerProgressBar");
+vi.mock("./../../../../components/Items/Misc/AudioPlayerPlaybackSpeed");
+
+describe("FullAudioPlayer", () => {
+	let mockHandlePlayPause: vi.Mock;
+	let mockHandleRepeat: vi.Mock;
+	let mockHandleRestart: vi.Mock;
+	let mockHandleAudioPlayerProgressBarClick: vi.Mock;
+	let mockSetPlaybackRate: vi.Mock;
+
+	beforeEach(() => {
+		mockHandlePlayPause = vi.fn();
+		mockHandleRepeat = vi.fn();
+		mockHandleRestart = vi.fn();
+		mockHandleAudioPlayerProgressBarClick = vi.fn();
+		mockSetPlaybackRate = vi.fn();
+        (AudioPlayerControls as vi.Mock).mockReturnValue(<div>AudioPlayerControls</div>);
+        (AudioPlayerProgressBar as vi.Mock).mockReturnValue(<div>AudioPlayerProgressBar</div>);
+        (AudioPlayerPlaybackSpeed as vi.Mock).mockReturnValue(<div>AudioPlayerPlaybackSpeed</div>);
+	});
+
+	afterEach(() => {
+		vi.clearAllMocks();
+    });
+
+    it("passes correct props to AudioPlayerControls", () => {
+        render(
+          <FullAudioPlayer
+            isPlaying={true}
+            currentTime={0}
+            duration={120}
+            playbackRate={1}
+            setPlaybackRate={mockSetPlaybackRate}
+            isRepeating={false}
+            handlePlayPause={mockHandlePlayPause}
+            handleRepeat={mockHandleRepeat}
+            handleRestart={mockHandleRestart}
+            handleAudioPlayerProgressBarClick={mockHandleAudioPlayerProgressBarClick}
+          />
+        );
+
+        expect(AudioPlayerControls).toHaveBeenCalledWith(
+          expect.objectContaining({
+            isPlaying: true,
+            isRepeating: false,
+            handlePlayPause: expect.any(Function),
+            handleRepeat: expect.any(Function),
+            handleRestart: expect.any(Function),
+          }),
+          {}
+        );
+      });
+
+
+	it("passes down the correct props to AudioPlayerProgressBar", () => {
+		render(
+			<FullAudioPlayer
+				isPlaying={true}
+				currentTime={10}
+				duration={20}
+				playbackRate={1}
+				setPlaybackRate={mockSetPlaybackRate}
+				isRepeating={false}
+				handlePlayPause={mockHandlePlayPause}
+				handleRepeat={mockHandleRepeat}
+				handleRestart={mockHandleRestart}
+				handleAudioPlayerProgressBarClick={mockHandleAudioPlayerProgressBarClick}
+			/>
+		);
+
+		expect(AudioPlayerProgressBar).toHaveBeenCalledWith(
+			expect.objectContaining({
+				currentTime: 10,
+				duration: 20,
+				handleAudioPlayerProgressBarClick: mockHandleAudioPlayerProgressBarClick,
+			}),
+			{}
+		);
+	});
+
+	it("passes down the correct props to AudioPlayerPlaybackSpeed", () => {
+		render(
+			<FullAudioPlayer
+				isPlaying={true}
+				currentTime={10}
+				duration={20}
+				playbackRate={1}
+				setPlaybackRate={mockSetPlaybackRate}
+				isRepeating={false}
+				handlePlayPause={mockHandlePlayPause}
+				handleRepeat={mockHandleRepeat}
+				handleRestart={mockHandleRestart}
+				handleAudioPlayerProgressBarClick={mockHandleAudioPlayerProgressBarClick}
+			/>
+		);
+
+		expect(AudioPlayerPlaybackSpeed).toHaveBeenCalledWith(
+			expect.objectContaining({
+				playbackRate: 1,
+				setPlaybackRate: mockSetPlaybackRate,
+			}),
+			{}
+		);
+	});
+
+});

--- a/frontend/src/__tests__/components/Items/Misc/MiniAudioPlayer.test.tsx
+++ b/frontend/src/__tests__/components/Items/Misc/MiniAudioPlayer.test.tsx
@@ -1,0 +1,35 @@
+import { describe, it, beforeEach, vi } from "vitest";
+import { render, fireEvent, screen } from "@testing-library/react";
+import MiniAudioPlayer from "./../../../../components/Items/Misc/MiniAudioPlayer";
+
+describe("MiniAudioPlayer", () => {
+  let mockHandlePlayPause: vi.Mock;
+
+  beforeEach(() => {
+    mockHandlePlayPause = vi.fn();
+  });
+
+  it("renders a play icon when isPlaying is false", () => {
+    render(<MiniAudioPlayer isPlaying={false} handlePlayPause={mockHandlePlayPause} />);
+
+    expect(screen.getByRole("button")).toBeInTheDocument();
+    expect(screen.getByTestId("testid-play-icon")).toBeInTheDocument();
+    expect(screen.queryByTestId("testid-pause-icon")).not.toBeInTheDocument();
+  });
+
+  it("renders a pause icon when isPlaying is true", () => {
+    render(<MiniAudioPlayer isPlaying={true} handlePlayPause={mockHandlePlayPause} />);
+
+    expect(screen.getByRole("button")).toBeInTheDocument();
+    expect(screen.getByTestId("testid-pause-icon")).toBeInTheDocument();
+    expect(screen.queryByTestId("testid-play-icon")).not.toBeInTheDocument();
+  });
+
+  it("calls handlePlayPause when the button is clicked", () => {
+    render(<MiniAudioPlayer isPlaying={false} handlePlayPause={mockHandlePlayPause} />);
+
+    fireEvent.click(screen.getByRole("button"));
+
+    expect(mockHandlePlayPause).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/__tests__/components/Items/Misc/TextToSpeechPlayer.test.tsx
+++ b/frontend/src/__tests__/components/Items/Misc/TextToSpeechPlayer.test.tsx
@@ -1,0 +1,79 @@
+import { render } from "@testing-library/react";
+import { describe, it, beforeEach, vi } from "vitest";
+import TextToSpeechPlayer from "./../../../../components/Items/Misc/TextToSpeechPlayer";
+import useAudioPlayer from "../../../../hooks/useAudioPlayer";
+import MiniAudioPlayer from "./../../../../components/Items/Misc/MiniAudioPlayer";
+import FullAudioPlayer from "./../../../../components/Items/Misc/FullAudioPlayer";
+
+vi.mock("../../../../hooks/useAudioPlayer");
+vi.mock("./../../../../components/Items/Misc/MiniAudioPlayer");
+vi.mock("./../../../../components/Items/Misc/FullAudioPlayer");
+
+describe("TextToSpeechPlayer", () => {
+	beforeEach(() => {
+		(useAudioPlayer as vi.Mock).mockReturnValue({
+			isPlaying: true,
+			isPaused: false,
+			isRepeating: false,
+			isRestarting: false,
+			currentTime: 0,
+			duration: 120,
+			playbackRate: 1,
+			handleAudioPlayerProgressBarClick: vi.fn(),
+			handlePlayPause: vi.fn(),
+			handleRepeat: vi.fn(),
+			handleRestart: vi.fn(),
+			setPlaybackRate: vi.fn(),
+		});
+	});
+
+	afterEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("displays the text when the displayText prop is true", () => {
+		const { getByText } = render(<TextToSpeechPlayer text="Test text" displayText={true} />);
+		expect(getByText("Test text")).toBeInTheDocument();
+	});
+
+	it("renders MiniAudioPlayer when miniPlayer prop is true", () => {
+		(MiniAudioPlayer as vi.Mock).mockReturnValue(<div>MiniAudioPlayer</div>);
+		render(<TextToSpeechPlayer text="Test text" miniPlayer={true} />);
+		expect(MiniAudioPlayer).toHaveBeenCalled();
+	});
+
+	it("renders FullAudioPlayer when miniPlayer prop is false", () => {
+		(FullAudioPlayer as vi.Mock).mockReturnValue(<div>FullAudioPlayer</div>);
+		render(<TextToSpeechPlayer text="Test text" miniPlayer={false} />);
+		expect(FullAudioPlayer).toHaveBeenCalled();
+	});
+
+	it("calls useAudioPlayer with correct parameters", () => {
+		render(<TextToSpeechPlayer text="Test text" mp3File="testFile.mp3" />);
+		expect(useAudioPlayer).toHaveBeenCalledWith({ text: "Test text", mp3File: "testFile.mp3" });
+	});
+
+	it("passes correct props to MiniAudioPlayer when miniPlayer is true", () => {
+		render(<TextToSpeechPlayer text="Test text" miniPlayer={true} />);
+		expect(MiniAudioPlayer).toHaveBeenCalledWith(expect.objectContaining({ isPlaying: true, handlePlayPause: expect.any(Function) }), {});
+	});
+
+	it("passes correct props to FullAudioPlayer when miniPlayer is false", () => {
+		render(<TextToSpeechPlayer text="Test text" miniPlayer={false} />);
+		expect(FullAudioPlayer).toHaveBeenCalledWith(
+			expect.objectContaining({
+				isPlaying: true,
+				currentTime: 0,
+				duration: 120,
+				playbackRate: 1,
+				isRepeating: false,
+				handlePlayPause: expect.any(Function),
+				handleRepeat: expect.any(Function),
+				handleRestart: expect.any(Function),
+				handleAudioPlayerProgressBarClick: expect.any(Function),
+				setPlaybackRate: expect.any(Function),
+			}),
+			{}
+		);
+	});
+});

--- a/frontend/src/components/Items/Misc/AudioPlayerControls.tsx
+++ b/frontend/src/components/Items/Misc/AudioPlayerControls.tsx
@@ -10,13 +10,13 @@ interface AudioPlayerControlsProps extends AudioPlayerProps {
 
 const AudioPlayerControls: React.FC<AudioPlayerControlsProps> = ({ isPlaying, isRepeating, handlePlayPause, handleRepeat, handleRestart }) => (
 	<div className="flex items-center justify-center space-x-4">
-		<button onClick={handleRestart} className="hover:bg-primary-300 hover:text-maintextalt rounded-full p-2">
+		<button onClick={handleRestart} data-testid={"testid-restart-button"} className="hover:bg-primary-300 hover:text-maintextalt rounded-full p-2">
 			<FiRewind size={24} />
 		</button>
-		<button onClick={handlePlayPause} className="hover:bg-primary-300 hover:text-maintextalt rounded-full p-2">
-			{isPlaying ? <FiPauseCircle size={24} /> : <FiPlayCircle size={24} />}
+		<button onClick={handlePlayPause} data-testid={"testid-playpause-button"} className="hover:bg-primary-300 hover:text-maintextalt rounded-full p-2">
+            {isPlaying ? <FiPauseCircle size={16} data-testid="testid-pause-icon" /> : <FiPlayCircle size={16} data-testid="testid-play-icon" />}
 		</button>
-		<button onClick={handleRepeat} className="hover:bg-primary-300 hover:text-maintextalt rounded-full p-2">
+		<button onClick={handleRepeat} data-testid={"testid-repeat-button"} className="hover:bg-primary-300 hover:text-maintextalt rounded-full p-2">
 			<FiRepeat size={24} className={`${isRepeating && "text-primary-600 rounded-full"}`} />
 		</button>
 	</div>

--- a/frontend/src/components/Items/Misc/AudioPlayerProgressBar.tsx
+++ b/frontend/src/components/Items/Misc/AudioPlayerProgressBar.tsx
@@ -1,10 +1,5 @@
 import { ChangeEvent } from "react";
-
-interface AudioPlayerProgressBarProps {
-	currentTime: number;
-	duration: number;
-	handleAudioPlayerProgressBarClick: (event: ChangeEvent<HTMLInputElement>) => void;
-}
+import { AudioPlayerProgressBarProps } from "../../../types/props";
 
 const AudioPlayerProgressBar: React.FC<AudioPlayerProgressBarProps> = ({ currentTime, duration, handleAudioPlayerProgressBarClick }) => (
 	<div className="w-full md:w-auto">

--- a/frontend/src/components/Items/Misc/MiniAudioPlayer.tsx
+++ b/frontend/src/components/Items/Misc/MiniAudioPlayer.tsx
@@ -5,7 +5,7 @@ const MiniAudioPlayer: React.FC<AudioPlayerProps> = ({ isPlaying, handlePlayPaus
 	<div className="bg-primary-200 inline-flex w-fit rounded-lg p-0 md:flex-row items-center justify-center md:space-y-0 md:space-x-4 shadow-lg hover:shadow-xl">
 		<div className="flex items-center justify-center space-x-4">
 			<button onClick={handlePlayPause} className="hover:bg-primary-300 hover:text-maintextalt rounded-full p-2">
-				{isPlaying ? <FiPauseCircle size={16} /> : <FiPlayCircle size={16} />}
+				{isPlaying ? <FiPauseCircle size={16} data-testid="testid-pause-icon" /> : <FiPlayCircle size={16} data-testid="testid-play-icon" />}
 			</button>
 		</div>
 	</div>

--- a/frontend/src/types/props.ts
+++ b/frontend/src/types/props.ts
@@ -1,6 +1,12 @@
-import { MouseEventHandler } from "react";
+import { ChangeEvent, MouseEventHandler } from "react";
 
 export interface AudioPlayerProps {
 	isPlaying: boolean;
 	handlePlayPause: MouseEventHandler<HTMLButtonElement>;
+}
+
+export interface AudioPlayerProgressBarProps {
+	currentTime: number;
+	duration: number;
+	handleAudioPlayerProgressBarClick: (event: ChangeEvent<HTMLInputElement>) => void;
 }


### PR DESCRIPTION
Create unit test for the TextToSpeechPlayer component and its children components

- Add `data-testid` attributes to `MiniAudioPlayer`, `AudioPlayerControls` components to aid in testing.
- Create comprehensive unit tests for each of the following components, checking rendering, user interactions, and prop handling.
-- TextToSpeechPlayer
-- MiniAudioPlayer
-- FullAudioPlayer
-- AudioPlayerControls
-- AudioPlayerPlaybackSpeed
-- AudioPlayerProgressBar

- Update components to ensure compatibility with testing, including adding necessary type information (Place AudioPlayerProgressBarProps inside props.ts).
- All tests are passing, and no regression has been observed in component behavior.